### PR TITLE
possible fox for time error/ initialization

### DIFF
--- a/src/hypelib.f90
+++ b/src/hypelib.f90
@@ -71,13 +71,13 @@ CONTAINS
     FUNCTION get_hype_time() RESULT(ret) bind(c, name="get_hype_time")
 
         USE, INTRINSIC :: ISO_C_BINDING
-        USE WORLDVAR,       ONLY : sdate
+        USE MODVAR,       ONLY : currentdate
 
         IMPLICIT NONE
 
         REAL(KIND=C_FLOAT)      :: ret
 
-        ret = convert_hype_time(sdate)
+        ret = convert_hype_time(currentdate)
 
     END FUNCTION get_hype_time
 
@@ -333,6 +333,7 @@ CONTAINS
 
         istat = 0
         iens = 1
+        idt=1
         
         CALL DATE_AND_TIME(logdate, logtime, values=datim)
 
@@ -512,6 +513,8 @@ CONTAINS
           CALL initiate_model(frozenstate, soilstate, aquiferstate, riverstate, lakestate, miscstate) 
       ENDIF
       oldyear = 0
+
+      istat=update()
 
     END FUNCTION initialize
 


### PR DESCRIPTION
this fixes the error where the get_current_time is not advanced leading to infinite loop in the update_until

the update in the initilization seems necessary to set the time to zero.

its only one of other possibilities; note that time now returns something with offset zero??

on other words, this is still not correct...