### PR TITLE
Dont ignore BMI_PORT with singularity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR third_party/protobuf
 RUN make install
 
 # Build bmi-c from source
-RUN git clone --depth=1 -b v0.2.3 https://github.com/eWaterCycle/grpc4bmi.git /opt/grpc4bmi
+RUN git clone --depth=1 -b v0.2.11 https://github.com/eWaterCycle/grpc4bmi.git /opt/grpc4bmi
 WORKDIR /opt/grpc4bmi
 RUN git submodule update --init --recursive
 RUN mkdir -p /opt/grpc4bmi/cpp/bmi-c/build


### PR DESCRIPTION
Fixes #9 

The `ewatercycle/hype-grpc4bmi:feb2021` image was published on DockerHub. Once PR is merged we can overwrite the `ewatercycle/hype-grpc4bmi:latest` image.

To test

```shell
docker build -t ewatercycle/hype-grpc4bmi:feb2021 .
singularity build --disable-cache ewatercycle-hype-grpc4bmi.sif docker-daemon://ewatercycle/hype-grpc4bmi:feb2021
singularity run --env BMI_PORT=54321 ewatercycle-hype-grpc4bmi.sif
BMI grpc server attached to server address 0.0.0.0:54321
```

The printed port should be the same as the BMI_PORT env var value.
